### PR TITLE
fix - Refatora os controladores para mover a lógica de acesso a dados…

### DIFF
--- a/webapp/controller/Roles.controller.ts
+++ b/webapp/controller/Roles.controller.ts
@@ -11,6 +11,7 @@ import UI5Event from "sap/ui/base/Event";
 import Fragment from "sap/ui/core/Fragment";
 import Dialog from "sap/m/Dialog";
 import Button from "sap/m/Button";
+import Api from "../model/Api";
 
 /**
  * @namespace com.alfa.cockpit.controller
@@ -20,14 +21,16 @@ import Button from "sap/m/Button";
  */
 export default class Roles extends Controller {
     private _oCreateDialog: Dialog;
+    private _api: Api;
 
     /**
      * @public
      * @override
      * @name onInit
-     * @description Inicializa o controller. Configura os modelos da view para o layout e o estado da view (modo de edição).
+     * @description Inicializa o controller. Configura os modelos da view e a classe de API.
      */
     public onInit(): void {
+        this._api = new Api(this);
         const oView = this.getView();
         if (oView) {
             oView.setModel(new JSONModel({ layout: LayoutType.OneColumn }), "appView");
@@ -39,7 +42,6 @@ export default class Roles extends Controller {
      * @public
      * @name onListItemPress
      * @description Manipulador para o evento de clique num item da lista de roles.
-     * Mostra a coluna de detalhe com a informação da role selecionada.
      * @param {sap.ui.base.Event} oEvent O evento de clique.
      */
     public onListItemPress(oEvent: UI5Event): void {
@@ -83,7 +85,7 @@ export default class Roles extends Controller {
     /**
      * @public
      * @name onCancelPress
-     * @description Cancela o modo de edição, revertendo quaisquer alterações no modelo OData e desativando o modo de edição.
+     * @description Cancela o modo de edição, revertendo quaisquer alterações e desativando o modo de edição.
      */
     public onCancelPress(): void {
         (this.getView()?.getModel() as ODataModel)?.resetChanges();
@@ -93,30 +95,20 @@ export default class Roles extends Controller {
     /**
      * @public
      * @name onSavePress
-     * @description Guarda as alterações feitas a uma role. Submete as alterações pendentes do modelo OData.
+     * @description Guarda as alterações feitas a uma role, usando a classe Api.
      */
     public onSavePress(): void {
-        const oView = this.getView();
-        if (!oView) return;
-        const oModel = oView.getModel() as ODataModel;
-        if (oModel.hasPendingChanges()) {
-            oModel.submitChanges({
-                success: () => {
-                    MessageToast.show("Role salva com sucesso.");
-                    (oView.getModel("viewModel") as JSONModel)?.setProperty("/editMode", false);
-                },
-                error: () => MessageBox.error("Falha ao salvar as alterações.")
-            });
-        } else {
-            MessageToast.show("Não existem alterações para salvar.");
-            (oView.getModel("viewModel") as JSONModel)?.setProperty("/editMode", false);
-        }
+        this._api.submitChanges("Role salva com sucesso.", "Falha ao salvar as alterações.")
+            .then(() => {
+                (this.getView()?.getModel("viewModel") as JSONModel)?.setProperty("/editMode", false);
+            })
+            .catch(oError => console.error(oError));
     }
 
     /**
      * @public
      * @name onDeletePress
-     * @description Apaga a role selecionada após confirmação do utilizador.
+     * @description Apaga a role selecionada após confirmação, usando a classe Api.
      * @param {sap.ui.base.Event} oEvent O evento de clique do botão de apagar.
      */
     public onDeletePress(oEvent: UI5Event): void {
@@ -124,18 +116,13 @@ export default class Roles extends Controller {
         if (!oContext) return;
         const sPath = oContext.getPath();
         const sName = oContext.getProperty("name") as string;
-        const oModel = this.getView()?.getModel() as ODataModel;
 
         MessageBox.confirm(`Tem a certeza que quer apagar a Role "${sName}"?`, {
             onClose: (sAction: string) => {
-                if (sAction === MessageBox.Action.OK && oModel) {
-                    oModel.remove(sPath, {
-                        success: () => {
-                            MessageToast.show("Role apagada com sucesso.");
-                            this.onCloseDetail();
-                        },
-                        error: () => MessageBox.error("Erro ao apagar a role.")
-                    });
+                if (sAction === MessageBox.Action.OK) {
+                    this._api.remove(sPath, "Role apagada com sucesso.", "Erro ao apagar a role.")
+                        .then(() => this.onCloseDetail())
+                        .catch(oError => console.error(oError));
                 }
             }
         });
@@ -144,7 +131,7 @@ export default class Roles extends Controller {
     /**
      * @public
      * @name onCreatePress
-     * @description Abre um diálogo para a criação de uma nova role. Carrega o fragmento do diálogo se ainda não tiver sido carregado.
+     * @description Abre um diálogo para a criação de uma nova role.
      */
     public async onCreatePress(): Promise<void> {
         const oView = this.getView();
@@ -164,24 +151,18 @@ export default class Roles extends Controller {
     /**
      * @public
      * @name onSaveNewRole
-     * @description Guarda a nova role criada através do diálogo. Valida os campos e chama o método 'create' do modelo OData.
+     * @description Guarda a nova role criada, usando a classe Api.
      */
     public onSaveNewRole(): void {
-        const oModel = this.getView()?.getModel() as ODataModel;
         const oNewData = (this._oCreateDialog.getModel("newRole") as JSONModel).getData();
         if (!oNewData.name || !oNewData.description) {
             MessageToast.show("Por favor, preencha todos os campos.");
             return;
         }
-        if(oModel){
-            oModel.create("/Roles", oNewData, {
-                success: () => {
-                    MessageToast.show("Role criada com sucesso.");
-                    this.onCancelNewRole();
-                },
-                error: () => MessageBox.error("Erro ao criar a Role.")
-            });
-        }
+
+        this._api.create("/Roles", oNewData, "Role criada com sucesso.", "Erro ao criar a Role.")
+            .then(() => this.onCancelNewRole())
+            .catch(oError => console.error(oError));
     }
 
     /**

--- a/webapp/model/Api.ts
+++ b/webapp/model/Api.ts
@@ -1,0 +1,130 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import ODataModel from "sap/ui/model/odata/v2/ODataModel";
+import MessageBox from "sap/m/MessageBox";
+import MessageToast from "sap/m/MessageToast";
+
+/**
+ * @namespace com.alfa.cockpit.model
+ * @class Api
+ * @description Classe genérica para interagir com o modelo OData.
+ * Abstrai as chamadas de criação, atualização e remoção, retornando Promises.
+ */
+export default class Api {
+    private controller: Controller;
+
+    /**
+     * @public
+     * @constructor
+     * @param {sap.ui.core.mvc.Controller} controller O controller que utilizará a API.
+     */
+    constructor(controller: Controller) {
+        this.controller = controller;
+    }
+
+    private _getModel(): ODataModel | null {
+        const oView = this.controller.getView();
+        if (oView) {
+            return oView.getModel() as ODataModel;
+        }
+        return null;
+    }
+
+    /**
+     * @public
+     * @name create
+     * @description Cria uma nova entrada no modelo OData.
+     * @param {string} path O caminho da entidade (ex: "/Users").
+     * @param {object} payload Os dados a serem criados.
+     * @param {string} successMessage Mensagem de sucesso a ser exibida.
+     * @param {string} errorMessage Mensagem de erro a ser exibida.
+     * @returns {Promise<object>} Uma Promise que resolve com os dados de resposta ou rejeita com o erro.
+     */
+    public create(path: string, payload: object, successMessage: string, errorMessage: string): Promise<object> {
+        return new Promise((resolve, reject) => {
+            const oDataModel = this._getModel();
+            if (!oDataModel) {
+                const error = "ODataModel não encontrado.";
+                MessageBox.error(error);
+                return reject(error);
+            }
+
+            oDataModel.create(path, payload, {
+                success: (oData: object) => {
+                    MessageToast.show(successMessage);
+                    resolve(oData);
+                },
+                error: (oError: any) => {
+                    MessageBox.error(errorMessage);
+                    reject(oError);
+                }
+            });
+        });
+    }
+
+    /**
+     * @public
+     * @name remove
+     * @description Remove uma entrada do modelo OData.
+     * @param {string} path O caminho para a entrada a ser removida (ex: "Users('123')").
+     * @param {string} successMessage Mensagem de sucesso a ser exibida.
+     * @param {string} errorMessage Mensagem de erro a ser exibida.
+     * @returns {Promise<object>} Uma Promise que resolve com os dados de resposta ou rejeita com o erro.
+     */
+    public remove(path: string, successMessage: string, errorMessage: string): Promise<object> {
+        return new Promise((resolve, reject) => {
+            const oDataModel = this._getModel();
+            if (!oDataModel) {
+                const error = "ODataModel não encontrado.";
+                MessageBox.error(error);
+                return reject(error);
+            }
+
+            oDataModel.remove(path, {
+                success: (oData: object) => {
+                    MessageToast.show(successMessage);
+                    resolve(oData);
+                },
+                error: (oError: any) => {
+                    MessageBox.error(errorMessage);
+                    reject(oError);
+                }
+            });
+        });
+    }
+
+    /**
+     * @public
+     * @name submitChanges
+     * @description Submete as alterações pendentes no modelo OData.
+     * @param {string} successMessage Mensagem de sucesso a ser exibida.
+     * @param {string} errorMessage Mensagem de erro a ser exibida.
+     * @returns {Promise<object>} Uma Promise que resolve com os dados de resposta ou rejeita com o erro.
+     */
+    public submitChanges(successMessage: string, errorMessage: string): Promise<object> {
+        return new Promise((resolve, reject) => {
+            const oDataModel = this._getModel();
+            if (!oDataModel) {
+                const error = "ODataModel não encontrado.";
+                MessageBox.error(error);
+                return reject(error);
+            }
+
+            if (oDataModel.hasPendingChanges()) {
+                oDataModel.submitChanges({
+                    success: (oData: object) => {
+                        MessageToast.show(successMessage);
+                        resolve(oData);
+                    },
+                    error: (oError: any) => {
+                        MessageBox.error(errorMessage);
+                        oDataModel.resetChanges();
+                        reject(oError);
+                    }
+                });
+            } else {
+                MessageToast.show("Nenhuma alteração para salvar.");
+                resolve({});
+            }
+        });
+    }
+}


### PR DESCRIPTION
… (create, update, delete) para uma classe de serviço genérica Api.ts.

      •
      Novo webapp/model/Api.ts: Cria um serviço reutilizável que encapsula as chamadas ao ODataModel (create, remove, submitChanges), retornando Promises e tratando o feedback ao usuário (Toast e MessageBox).
      •
      Refatoração dos Controladores: Os controladores Users, Roles e RolesCollections foram atualizados para instanciar e utilizar o novo serviço Api, removendo a lógica duplicada e simplificando o código.
      •
      Correção de Bug: Corrige um TypeError que ocorria no onInit ao instanciar a classe Api. A classe agora recebe a instância do controlador e obtém o modelo OData dinamicamente, garantindo que ele esteja sempre disponível no momento da chamada.